### PR TITLE
M3 Ultra ANE support: matmul RoPE + dispatch refresh

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,141 @@
+# Contributing to Rustane
+
+Thanks for your interest in ANE training research. This project is actively developed and we welcome contributions.
+
+## Getting Started
+
+```bash
+git clone https://github.com/ncdrone/rustane.git
+cd rustane
+cargo build
+cargo test -p engine --release
+```
+
+Requires:
+- Rust 1.94.0+
+- macOS 15+
+- Apple Silicon (M1 or later)
+- 18GB+ RAM (64GB+ recommended for billion-scale)
+
+## Running Tests
+
+```bash
+# Unit tests (no ANE hardware needed for most)
+cargo test -p engine --release
+
+# Training validation at 600M (needs ANE, ~17s)
+cargo test -p engine --test bench_param_sweep --release -- --ignored --nocapture sweep_600m_a
+
+# Full parameter sweep 600M-5B (~60 min, needs 85GB+ RAM)
+cargo test -p engine --test bench_param_sweep --release -- --ignored --nocapture sweep_full
+
+# Forward-only scale ladder 5B-30B (~8 min, needs 128GB)
+cargo test -p engine --test bench_fwd_only_scale --release -- --ignored --nocapture fwd_scale_ladder
+```
+
+## Submitting a PR
+
+1. Fork the repo
+2. Create a branch from `master`
+3. Make your changes
+4. Run `cargo test -p engine --release` (all unit tests must pass)
+5. Run at least one `--ignored` benchmark test relevant to your change
+6. Open a PR against `master`
+
+### PR checklist
+
+- [ ] `cargo check` passes
+- [ ] `cargo test -p engine --release` passes (28 unit tests + integration tests)
+- [ ] Relevant benchmark test passes (if touching engine code)
+- [ ] No new warnings from `cargo check`
+- [ ] Commit messages describe what changed and why
+
+## What We Need Help With
+
+### High impact
+- **GPU backward pass** — Metal compute shaders for backward matmuls (currently CPU-bound, 63-67% of step time)
+- **Long training runs** — 10K+ step validation on real data at 600M-1.5B
+- **M3 Ultra testing** — see below
+
+### Medium impact
+- IOSurface-native weight storage (zero-copy staging)
+- Workspace correctness tests (forward_ws vs forward equivalence)
+- Mixed precision experiments
+
+### Research
+- GQA (grouped query attention) support
+- Sequence length scaling beyond 512
+- ANE kernel fusion strategies at different dims
+
+## M3 Ultra Contributors
+
+If you have access to an M3 Ultra (192GB or 512GB), we have a dedicated branch for you:
+
+**Branch: `m3-ultra`**
+
+The M3 Ultra has 2 ANE dies (2x the ANE cores of a Max). We want to know:
+
+1. **Does training work at 10B+?** The 192GB model should fit ~10B training state comfortably. The 512GB model could reach 20B.
+2. **Does Apple's ANE scheduler split work across both dies?** If so, we'd expect ~2x ANE throughput vs Max. If not, one die sits idle.
+3. **What happens at dim=5120+?** We found an efficiency cliff at dim=5120 on M4 Max. Does the Ultra behave the same?
+
+To test:
+```bash
+git checkout m3-ultra
+
+# Training validation at 10B (should fit on 192GB)
+cargo test -p engine --test bench_param_sweep --release -- --ignored --nocapture sweep_10b
+
+# Forward pass — push to 50B+ on 512GB
+cargo test -p engine --test bench_fwd_only_scale --release -- --ignored --nocapture fwd_find_ceiling
+```
+
+Report your results as an issue with the `m3-ultra` label. Include:
+- Chip model (M3 Ultra)
+- RAM (192GB or 512GB)
+- macOS version
+- Output from the test run
+
+Even a single test result from an Ultra is valuable. Nobody has published ANE data from this hardware.
+
+## Project Structure
+
+```
+crates/
+  ane-bridge/     — Rust FFI to ANE private APIs
+  metal-decode/   — Metal shaders for decode (planned)
+  engine/         — Training orchestrator
+    src/
+      bin/train.rs    — Training binary with CLI flags
+      full_model.rs   — Forward/backward/train_step
+      layer.rs        — Per-layer ANE kernels
+      model.rs        — Model configs (48M to 5B+)
+      cpu/            — Accelerate FFI, Adam, RMSNorm, etc.
+    tests/
+      bench_*.rs      — Benchmarks (--ignored, run manually)
+      auto_*.rs       — A/B optimization tests
+      phase*.rs       — Phase validation tests
+results/              — Benchmark results and sweep data
+```
+
+## ANE Gotchas
+
+If you're touching ANE kernel code:
+
+- IOSurface spatial width must be multiple of 16 (silent data corruption otherwise)
+- dim must be divisible by 128, hidden must be divisible by 16
+- ANE compiler fails on rsqrt/sqrt after reduce ops — use pow(-0.5)
+- Per-dispatch overhead is ~0.095ms (XPC + IOKit round-trip)
+- IOSurface stores fp32, ANE casts to fp16 internally
+- `sgemm_at` uses beta=1.0 — always zero the output buffer first
+
+## Code Style
+
+- No unnecessary abstractions — three similar lines beats a premature helper
+- Keep commits focused — one change per commit
+- Commit messages: what changed and why, not just what
+- No docs/comments on code you didn't change
+
+## License
+
+By contributing, you agree that your contributions will be licensed under MIT.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,75 @@
+# Rustane — common commands
+#
+# Run `make help` to see all available targets.
+
+.PHONY: help build test sweep-600m sweep-1b sweep-3b sweep-5b sweep-full \
+	forward-ladder forward-ceiling forward-7b forward-10b train-600m
+
+help: ## Show this help
+	@echo "  Rustane — available commands:"
+	@echo ""
+	@echo "  make build                Build all crates"
+	@echo "  make test                 Run all unit + integration tests"
+	@echo ""
+	@echo "  Training validation:"
+	@echo "  make sweep-600m           Validate at 600M (~17s)"
+	@echo "  make sweep-1b             Validate at 1B (~35s)"
+	@echo "  make sweep-3b             Validate at 3B (~80s, needs 55GB)"
+	@echo "  make sweep-5b             Validate at 5B (~150s, needs 85GB)"
+	@echo "  make sweep-full           All 25 configs, 600M-5B (~60 min, needs 85GB)"
+	@echo ""
+	@echo "  Forward-only probes:"
+	@echo "  make forward-7b           Forward pass at 7B (~30s, needs 31GB)"
+	@echo "  make forward-10b          Forward pass at 10B (~45s, needs 46GB)"
+	@echo "  make forward-ladder       Forward pass 5B to 20B (~8 min, needs 93GB)"
+	@echo "  make forward-ceiling      Forward pass 25B/30B (~10 min, needs 130GB)"
+	@echo ""
+	@echo "  Training on real data:"
+	@echo "  make train-600m DATA=/path/to/train.bin"
+
+build: ## Build all crates
+	cargo build
+
+test: ## Run all unit + integration tests
+	cargo test -p engine --release
+
+# ── Training validation ─────────────────────────────────────────────
+
+sweep-600m: ## Validate training pipeline at 600M (~17s)
+	cargo test -p engine --test bench_param_sweep --release -- --ignored --nocapture sweep_600m_a
+
+sweep-1b: ## Validate training pipeline at 1B (~35s)
+	cargo test -p engine --test bench_param_sweep --release -- --ignored --nocapture sweep_1b_a
+
+sweep-3b: ## Validate training pipeline at 3B (~80s, needs 55GB)
+	cargo test -p engine --test bench_param_sweep --release -- --ignored --nocapture sweep_3b_a
+
+sweep-5b: ## Validate training pipeline at 5B (~150s, needs 85GB)
+	cargo test -p engine --test bench_param_sweep --release -- --ignored --nocapture sweep_5b_a
+
+sweep-full: ## Full parameter sweep, 25 configs, 600M-5B (~60 min, needs 85GB)
+	cargo test -p engine --test bench_param_sweep --release -- --ignored --nocapture sweep_full
+
+# ── Forward-only scale probes ────────────────────────────────────────
+
+forward-ladder: ## Forward pass 5B to 20B (~8 min, needs 93GB)
+	cargo test -p engine --test bench_fwd_only_scale --release -- --ignored --nocapture fwd_scale_ladder
+
+forward-ceiling: ## Push forward pass to 25B/30B (~10 min, needs 130GB)
+	cargo test -p engine --test bench_fwd_only_scale --release -- --ignored --nocapture fwd_find_ceiling
+
+forward-7b: ## Single forward pass at 7B (~30s, needs 31GB)
+	cargo test -p engine --test bench_fwd_only_scale --release -- --ignored --nocapture fwd_7b
+
+forward-10b: ## Single forward pass at 10B (~45s, needs 46GB)
+	cargo test -p engine --test bench_fwd_only_scale --release -- --ignored --nocapture fwd_10b
+
+# ── Real data training ───────────────────────────────────────────────
+
+train-600m: ## Train 600M on real data (needs climbmix-400B data file)
+	cargo run -p engine --release --bin train -- \
+		--model custom:1536,4096,20,512 --data $(DATA) \
+		--lr 3e-4 --accum 1 --warmup 100 \
+		--embed-lr 1.0 --beta2 0.99 \
+		--loss-scale 1 --grad-clip 1 \
+		--steps 72000

--- a/README.md
+++ b/README.md
@@ -36,11 +36,26 @@ The engine trains transformer models at 3-5W power draw, leaving the GPU complet
 
 No ANE compilation ceiling found. The limit is RAM, not the chip.
 
+### M5 Max Forward-Only Results
+
+Community results from [Anemll](https://github.com/Anemll) testing on M5 Max 128GB:
+
+| Scale | M4 Max | M5 Max | Speedup |
+|-------|--------|--------|---------|
+| 5B | 2,064ms | 1,910ms | 8% |
+| 7B | 3,132ms | 2,878ms | 8% |
+| 10B | 4,696ms | 4,329ms | 8% |
+| 13B | 21,962ms | 20,270ms | 8% |
+| 15B | 26,740ms | 24,303ms | 9% |
+| 20B | 40,933ms | 32,380ms | **21%** |
+
+Steady 8% faster at 5B-15B, 21% at 20B. The dim=5120 efficiency cliff is present on both chips.
+
 ### Key Findings
 
 - **Architecture crossover at 3B**: wide+shallow wins below (fewer ANE dispatches), deep+narrow wins above (smaller matmuls more efficient)
 - **Efficiency cliff at dim=5120**: forward time jumps 4.7x per layer. Keep dim at or below 4096 for ANE.
-- **Practical training ceiling**: ~5B on 128GB. An M3/M4 Ultra with 512GB could reach ~20B.
+- **Practical training ceiling**: ~5B on 128GB. An M3 Ultra with 512GB could reach ~20B.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -93,13 +93,19 @@ cargo run -p engine --release --bin train -- \
 
 ## Hardware Requirements
 
+Any Apple Silicon Mac with 18GB+ RAM. The ANE is the same 16-core design across M1-M4. Only RAM differs.
+
+Tested on M4 Max 128GB. Other configs are estimates based on RAM scaling.
+
 | Hardware | Memory | Training Ceiling | Forward Ceiling |
 |----------|--------|-----------------|-----------------|
-| M4 Max 128GB | 128 GB | **~5B** (85GB) | **~30B** (130GB) |
-| M4 Max 64GB | 64 GB | ~3B | ~15B |
-| M4 Pro 48GB | 48 GB | ~1.5B | ~10B |
-| M4 Pro 24GB | 24 GB | ~600M | ~5B |
-| M3/M4 Ultra 512GB | 512 GB | ~20B | ~100B+ |
+| M1/M2/M3 Pro 18GB | 18 GB | ~300M | ~3B |
+| M1/M2/M3 Pro 36GB | 36 GB | ~1B | ~7B |
+| M1/M2/M3/M4 Max 64GB | 64 GB | ~3B | ~15B |
+| M3/M4 Max 96GB | 96 GB | ~5B | ~20B |
+| **M3/M4 Max 128GB** | **128 GB** | **~5B** (tested) | **~30B** (tested) |
+| M3 Ultra 192GB | 192 GB | ~10B | ~40B+ |
+| M3 Ultra 512GB | 512 GB | ~20B | ~100B+ |
 
 ## ANE Gotchas
 

--- a/crates/engine/src/bin/train.rs
+++ b/crates/engine/src/bin/train.rs
@@ -255,7 +255,9 @@ fn main() {
     // On M3/M4 Ultra (dual-die), ANE eval calls accumulate internal firmware
     // state that degrades throughput after ~100K dispatches. Periodic recompile
     // resets this state. Cost: ~1s every N steps. Set to 0 to disable.
-    let ane_refresh_interval: u32 = 150;
+    // Tuned for M3 Ultra 600M: degradation starts at ~43 steps (~28K dispatches).
+    // Refresh at 40 keeps step times at 1.0s with ~2.5% overhead from recompile.
+    let ane_refresh_interval: u32 = 40;
 
     // Init model + Metal Adam optimizer
     let metal_adam = MetalAdam::new().expect("Metal GPU required for training");

--- a/crates/engine/src/bin/train.rs
+++ b/crates/engine/src/bin/train.rs
@@ -249,8 +249,13 @@ fn main() {
     // Compile kernels
     println!("\nCompiling 10 ANE kernels...");
     let t0 = Instant::now();
-    let kernels = CompiledKernels::compile(&cfg);
+    let mut kernels = CompiledKernels::compile(&cfg);
     println!("  compiled in {:.1}s", t0.elapsed().as_secs_f32());
+
+    // On M3/M4 Ultra (dual-die), ANE eval calls accumulate internal firmware
+    // state that degrades throughput after ~100K dispatches. Periodic recompile
+    // resets this state. Cost: ~1s every N steps. Set to 0 to disable.
+    let ane_refresh_interval: u32 = 150;
 
     // Init model + Metal Adam optimizer
     let metal_adam = MetalAdam::new().expect("Metal GPU required for training");
@@ -356,6 +361,15 @@ fn main() {
             if (step + 1) % args.checkpoint_interval == 0 || step + 1 == tc.total_steps {
                 save_checkpoint(&cfg, &weights, &opt, step + 1, dir);
             }
+        }
+
+        // Periodic ANE refresh: drop compiled kernels and recompile to reset
+        // firmware state. Prevents eval dispatch degradation on long runs.
+        if ane_refresh_interval > 0 && (step + 1) % ane_refresh_interval == 0 && step + 1 < tc.total_steps {
+            let rt0 = Instant::now();
+            drop(kernels);
+            kernels = CompiledKernels::compile(&cfg);
+            println!("  [ANE refresh in {:.2}s]", rt0.elapsed().as_secs_f32());
         }
     }
 

--- a/crates/engine/src/kernels/sdpa_fwd.rs
+++ b/crates/engine/src/kernels/sdpa_fwd.rs
@@ -1,5 +1,8 @@
 //! SDPA Forward kernel: QKV projection + RoPE + attention + output.
 //!
+//! RoPE uses matmul-based permutation (M3/M4 Ultra compatible) instead of
+//! width-axis reshape/slice/concat (M4 Max only).
+//!
 //! Input IOSurface: [1, DIM, 1, SEQ + Q_DIM + KV_DIM + KV_DIM]
 //!   sp[0:SEQ]                     = xnorm [DIM, SEQ]
 //!   sp[SEQ:SEQ+Q_DIM]             = Wq [DIM, Q_DIM]
@@ -43,6 +46,22 @@ fn causal_mask(seq: usize) -> Vec<f32> {
         }
     }
     mask
+}
+
+/// Build rotate_half permutation matrix P (hd × hd).
+///
+/// Implements rotate_half([x0,x1,x2,x3,...]) = [-x1,x0,-x3,x2,...] via matmul.
+/// This avoids width-axis reshape/slice/concat ops that M3 Ultra's ANE rejects.
+///
+///   P[2i+1, 2i] = -1  (negate odd → even position)
+///   P[2i, 2i+1] = 1   (copy even → odd position)
+fn rope_permutation_matrix(hd: usize) -> Vec<f32> {
+    let mut perm = vec![0.0f32; hd * hd];
+    for i in 0..hd / 2 {
+        perm[(2 * i + 1) * hd + 2 * i] = -1.0;
+        perm[(2 * i) * hd + 2 * i + 1] = 1.0;
+    }
+    perm
 }
 
 /// Build the SDPA forward graph.
@@ -97,32 +116,25 @@ pub fn build(cfg: &ModelConfig) -> Graph {
     let v4 = g.reshape(vf, Shape { batch: 1, channels: heads, height: hd, width: seq });
     let v = g.transpose(v4, [0, 1, 3, 2]);
 
-    // ── RoPE ──
+    // ── RoPE via matmul permutation ──
+    // rotate_half(x) = x @ P where P is a constant hd×hd permutation matrix.
+    // This replaces the width-axis reshape/slice/concat pattern which fails on
+    // M3 Ultra's ANE. The 128×128 sparse matmul is negligible cost compared to
+    // the QKV projections. Works on all Apple Silicon generations.
     let (cos_data, sin_data) = rope_table(seq, hd);
     let rope_cos = g.constant(&cos_data, Shape { batch: 1, channels: 1, height: seq, width: hd });
     let rope_sin = g.constant(&sin_data, Shape { batch: 1, channels: 1, height: seq, width: hd });
+    let perm_data = rope_permutation_matrix(hd);
+    let perm = g.constant(&perm_data, Shape { batch: 1, channels: 1, height: hd, width: hd });
 
-    // rotate_half(q): split pairs, negate odd, concat reversed, reshape back
-    let pairs_q = seq * hd / 2;
-    let q_p = g.reshape(q, Shape { batch: 1, channels: heads, height: pairs_q, width: 2 });
-    let q_e = g.slice(q_p, [0, 0, 0, 0], [1, heads, pairs_q, 1]); // even
-    let q_o = g.slice(q_p, [0, 0, 0, 1], [1, heads, pairs_q, 1]); // odd
-    let neg1 = g.constant_with_scalar(-1.0, Shape { batch: 1, channels: 1, height: 1, width: 1 });
-    let nq = g.multiplication(q_o, neg1);
-    let qrp = g.concat(&[nq, q_e], 3); // [-odd, even] → rotated
-    let q_rot = g.reshape(qrp, Shape { batch: 1, channels: heads, height: seq, width: hd });
+    // q_rope = q * cos + (q @ P) * sin
+    let q_rot = g.matrix_multiplication(q, perm, false, false);
     let qc = g.multiplication(q, rope_cos);
     let qrs = g.multiplication(q_rot, rope_sin);
     let q_rope = g.addition(qc, qrs);
 
-    // rotate_half(k): same pattern
-    let pairs_k = seq * hd / 2;
-    let k_p = g.reshape(k, Shape { batch: 1, channels: heads, height: pairs_k, width: 2 });
-    let k_e = g.slice(k_p, [0, 0, 0, 0], [1, heads, pairs_k, 1]);
-    let k_o = g.slice(k_p, [0, 0, 0, 1], [1, heads, pairs_k, 1]);
-    let nk = g.multiplication(k_o, neg1);
-    let krp = g.concat(&[nk, k_e], 3);
-    let k_rot = g.reshape(krp, Shape { batch: 1, channels: heads, height: seq, width: hd });
+    // k_rope = k * cos + (k @ P) * sin
+    let k_rot = g.matrix_multiplication(k, perm, false, false);
     let kc = g.multiplication(k, rope_cos);
     let krs = g.multiplication(k_rot, rope_sin);
     let k_rope = g.addition(kc, krs);

--- a/results/2026-03-19_m3ultra_report.md
+++ b/results/2026-03-19_m3ultra_report.md
@@ -1,0 +1,91 @@
+# M3 Ultra (512GB) Test Report — 2026-03-19
+
+**Hardware:** Mac Studio M3 Ultra, 32-core CPU, 80-core GPU, 32-core Neural Engine, 512GB RAM
+**OS:** macOS 26.3.1 (Tahoe) build 25D2128
+**Rust:** 1.94.0
+**Tester:** Jack Zampolin (amygdala project)
+
+## Summary
+
+6 of 8 ANE kernels compile and run correctly on M3 Ultra. The `sdpaFwd` kernel fails at ANE compilation due to `concat` MIL ops that M3 Ultra's ANE rejects. This blocks training but is fixable.
+
+## Test Results
+
+### Phase 0 — ANE Basics
+
+| Test | Result | Notes |
+|------|--------|-------|
+| compile_graph_with_multiple_constants_on_ane | PASS | `(1+1)*2 = 4.0` correct |
+| iosurface_raii_lock_guards_work | PASS | |
+| iosurface_write_read_roundtrip | FAIL | fp16 precision: expected 0.01, got 0.010002136. Strict assert, not a real problem. |
+
+### Phase 3 — Kernel Compilation
+
+| Kernel | Compile | Run | Notes |
+|--------|---------|-----|-------|
+| DualDynMatmul | PASS | PASS | |
+| woFwd | PASS | PASS | output sum=73927144.00 |
+| ffnFused | PASS | PASS | out_ch=6912, sum=3756007.75 |
+| ffnBwdW2t | PASS | PASS | output sum=197037440.00 |
+| sdpaBwd1 | PASS | PASS | in_ch=3072, out_ch=6912, sum=5479.27 |
+| sdpaBwd2 | PASS | PASS | in_ch=7680, out_ch=1536 |
+| **sdpaFwd** | **FAIL** | — | `_ANECompiler : ANECCompile() FAILED` |
+| all_forward_1000_iters | FAIL | — | Depends on sdpaFwd |
+
+### Phase 4 — Training
+
+| Test | Result | Notes |
+|------|--------|-------|
+| forward_produces_valid_loss | FAIL | sdpaFwd compile failure |
+| six_layer_loss_decreases | FAIL | sdpaFwd compile failure |
+
+## Root Cause
+
+`sdpaFwd` uses `concat` MIL op in 3 places (`crates/engine/src/kernels/sdpa_fwd.rs`):
+
+1. **Line 112** — RoPE rotation for Q: `g.concat(&[nq, q_e], 3)` (axis=width)
+2. **Line 124** — RoPE rotation for K: `g.concat(&[nk, k_e], 3)` (axis=width)
+3. **Line 158** — Output assembly: `g.concat(&[af, qrf, krf, vf, xn], 1)` (axis=channels)
+
+**M4 Max accepts `concat` in MIL graphs. M3 Ultra does not.** This is a known ANE constraint ("concat op banned, must use multi-output programs") documented in `mechramc/Orion/docs/ane_constraints.md` — M4 appears to have relaxed this constraint.
+
+## Suggested Fixes
+
+### RoPE concat (lines 112, 124) — arithmetic replacement
+
+The RoPE rotation `[-x_odd, x_even]` concat can be replaced with pure arithmetic:
+
+```
+// Instead of: concat([-odd, even], axis=3) → reshape
+// Use: x * interleave_signs + rotate_left(x) * interleave_mask
+// Or split the rotation into multiply + negate + add without concat
+```
+
+Specifically: `rotated_half(x) = x_even * cos - x_odd * sin` for even indices and `x_odd * cos + x_even * sin` for odd indices. This can be expressed as element-wise multiply + add with pre-computed sign-flip tensors, avoiding concat entirely.
+
+### Output concat (line 158) — multi-output split
+
+Split `sdpaFwd` into 2-3 separate ANE programs:
+1. **sdpaFwd_qkv** — QKV projection + RoPE → outputs Q_rope, K_rope, V (3 separate IOSurfaces)
+2. **sdpaFwd_attn** — attention scores + softmax + V matmul → output attn_out
+
+This matches Orion's approach: "Must use multi-output programs" for the concat constraint.
+
+## Environment
+
+```
+Build: cargo build --release — 25.01s, clean compile
+Data: 631M training tokens prepared (climbmix-400B, 10 shards, uint16)
+      63M validation tokens (1 shard)
+      token_bytes.bin (8192 entries)
+All data ready at /Users/admin/rustane/data/ on Studio-2.
+```
+
+## What We Can Test Once sdpaFwd Is Fixed
+
+The M3 Ultra with 512GB is the ideal machine for pushing scale:
+- **Training at 10-20B** (estimated 200-340GB RAM)
+- **Forward pass at 50-100B+** (M4 Max hit 30B at 130GB)
+- **ANE perf comparison**: M3 Ultra has 31.6 TFLOPS ANE vs M4 Max ~19 TFLOPS — potentially faster per-kernel
+
+Data prep is complete and waiting. Happy to re-run the moment a fix lands.


### PR DESCRIPTION
## Summary

Tested rustane on **M3 Ultra (512GB, macOS 26.3.1)**. Two issues found and fixed:

- **RoPE compile failure**: M3 Ultra's ANE rejects width-axis reshape/slice/concat ops in `sdpaFwd`. Replaced `rotate_half` with a constant hd×hd permutation matrix matmul — `rotate_half(x) = x @ P`. Works on all Apple Silicon (M3, M4, Ultra).
- **ANE dispatch degradation**: On dual-die Ultra chips, ANE throughput degrades after ~100K cumulative `doEvaluateDirectWithModel:` calls (~150 steps at 600M). Added periodic kernel recompile to reset firmware state.

## Changes

- `crates/engine/src/kernels/sdpa_fwd.rs` — Replace reshape/slice/concat RoPE with matmul permutation (+30/-18 lines)
- `crates/engine/src/bin/train.rs` — Add `ane_refresh_interval` periodic recompile (+15/-1 lines)
- `results/2026-03-19_m3ultra_report.md` — Full test report with kernel compatibility matrix

## Test Results (M3 Ultra 512GB)

| Test | Result |
|------|--------|
| Phase 0: ANE basics | 2/3 pass (1 strict fp16 assert) |
| Phase 3: All 8 kernels | **8/8 pass** (was 6/8 before fix) |
| Phase 3: 1000-iter stress | **pass** |
| Phase 4: Forward loss | **pass** (9.0117) |
| Phase 4: 6-layer training | **pass** (9.01 → 8.83, 10 steps) |
| 600M real data (climbmix-400B) | **loss 9.01 → 8.20** (500 steps) |

## Known Issue: Dual-Die ANE Scheduling

The M3 Ultra has two ANE units (two M3 Max dies via UltraFusion). We discovered via ObjC runtime introspection that `_ANEDeviceController` exposes `device`/`setDevice:` and `aned` references `forAllSegments` — suggesting explicit dual-segment dispatch is possible but not yet implemented in the `ane` crate.

Current workaround (periodic recompile) keeps step times stable but doesn't utilize both ANE dies. Full dual-die tensor parallelism is the next step — would roughly double ANE throughput on Ultra.

Relevant private APIs discovered:
- `_ANEDeviceController`: `device`, `setDevice:`, `start`, `stop`, `initWithProgramHandle:priviledged:`
- `_ANEClient`: `doPrepareChainingWithModel:options:chainingReq:qos:error:` (cross-segment chaining)
- `aned`: `URLForModel:bundleID:forAllSegments:` (multi-segment model loading)

## Test Plan

- [x] Phase 3 kernel tests pass on M3 Ultra
- [x] Phase 4 training tests pass on M3 Ultra
- [x] Real data training produces decreasing loss
- [ ] Verify no regression on M4 Max (matmul RoPE should be equivalent)
- [ ] Long run (10K+ steps) with ANE refresh to confirm stability

🤖 Generated with [Claude Code](https://claude.com/claude-code)